### PR TITLE
add environ keys to the defaults

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,17 +39,17 @@ exposes ``get_wsgi_app``, ``get_wsgi_app_settings``, ``get_wsgi_filter`` and
     settings = loader.get_settings('app:main')
 
     # to get settings for a WSGI app
-    app_config = loader.get_wsgi_app_settings() # defaults to main
+    app_config = loader.get_wsgi_app_settings()  # defaults to main
 
     # to get an actual WSGI app
-    app = loader.get_wsgi_app() # defaults to main
+    app = loader.get_wsgi_app()  # defaults to main
 
     # to get a filter and compose it with an app
     filter = loader.get_wsgi_filter('filt')
     app = filter(app)
 
     # to get a WSGI server
-    server = loader.get_wsgi_server() # defaults to main
+    server = loader.get_wsgi_server()  # defaults to main
 
     # to start the WSGI server
     server(app)
@@ -66,6 +66,28 @@ Some examples are below:
 - ``pastedeploy+ini://development.ini#foo``
 
 - ``egg:MyApp?debug=false#foo``
+
+Environment Variables
+---------------------
+
+This binding extends ``pastedeploy`` to inject environ variables as defaults
+which are available to use in the INI file. Each ``os.environ`` key is prefixed
+with ``ENV_`` and added as a default.
+
+For example:
+
+.. code-block:: ini
+
+   [app:main]
+   debug = %(ENV_APP_DEBUG)s
+
+The only thing to be aware of here is that there is no fallback. The INI file
+will fail to parse if the environment variable is not set. The app may be run
+like so:
+
+.. code-block:: bash
+
+   $ APP_DEBUG=true env/bin/pserve development.ini
 
 .. _PasteDeploy: http://pastedeploy.readthedocs.io/en/latest/
 .. _plaster: http://docs.pylonsproject.org/projects/plaster/en/latest/

--- a/src/plaster_pastedeploy/__init__.py
+++ b/src/plaster_pastedeploy/__init__.py
@@ -222,6 +222,7 @@ class Loader(IWSGIProtocol, ILoader):
             '__file__': path,
             'here': os.path.dirname(path),
         }
+        result.update({'ENV_' + k: v for k, v in os.environ.items()})
         result.update(self.uri.options)
         if defaults:
             result.update(defaults)
@@ -229,11 +230,9 @@ class Loader(IWSGIProtocol, ILoader):
 
     def _get_parser(self, defaults=None):
         defaults = self._get_defaults(defaults)
-        parser = loadwsgi.NicerConfigParser(self.uri.path, defaults=defaults)
-        parser.optionxform = str
-        with open(parser.filename) as fp:
-            parser.read_file(fp)
-        return parser
+        loader = loadwsgi.ConfigLoader(self.uri.path)
+        loader.update_defaults(defaults)
+        return loader.parser
 
     def _maybe_get_default_name(self, name):
         """Checks a name and determines whether to use the default name.

--- a/tests/sample_configs/test_settings.ini
+++ b/tests/sample_configs/test_settings.ini
@@ -12,3 +12,6 @@ set default_b = override_b
 a = a_val
 b = b_val
 c = %(default_c)s
+
+[section3]
+foo = %(ENV_PLASTER_FOO)s

--- a/tests/test_get_settings.py
+++ b/tests/test_get_settings.py
@@ -17,7 +17,7 @@ class TestSimpleUri(object):
 
     def test_sections(self):
         result = self.loader.get_sections()
-        assert set(result) == {'section1', 'section2'}
+        assert set(result) == {'section1', 'section2', 'section3'}
 
     def test_missing_section(self):
         result = self.loader.get_settings('missing', {'a': 'b'})
@@ -46,6 +46,10 @@ class TestSimpleUri(object):
         assert result['b'] == 'b_val'
         assert result['c'] == 'default_c'
 
+    def test_environ_passed(self, monkeypatch):
+        monkeypatch.setenv('PLASTER_FOO', 'bar')
+        result = self.loader.get_settings('section3')
+        assert result['foo'] == 'bar'
 
 class TestSectionedURI(TestSimpleUri):
     config_uri = test_settings_path + '#section1'

--- a/tests/test_get_wsgi_app_settings.py
+++ b/tests/test_get_wsgi_app_settings.py
@@ -14,11 +14,12 @@ class TestFullURI(object):
         self.loader = plaster.get_loader(
             test_config_relpath, protocols=['wsgi'])
 
-    def test_get_wsgi_app_settings(self):
+    def test_get_wsgi_app_settings(self, monkeypatch):
         from collections import OrderedDict
         from paste.deploy import loadwsgi
         from plaster_pastedeploy import ConfigDict
 
+        monkeypatch.setattr('os.environ', {})
         conf = self.loader.get_wsgi_app_settings('test_get')
 
         assert conf == {


### PR DESCRIPTION
The only super annoying part about this is that I discovered that pastedeploy returns a merged dict of defaults and local settings for `paste.deploy.loadwsgi.appconfig` meaning the environment variables show up in `get_wsgi_app_settings`. I'm not super happy about that and might fix that separately.