### PR TITLE
make get_wsgi_app_settings return only the local conf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ unreleased
   variable ``APP_DEBUG=true`` then ``%(ENV_APP_DEBUG)s`` will work within the
   ini file. See https://github.com/Pylons/plaster_pastedeploy/pull/7
 
+- ``get_settings`` and ``get_wsgi_app_settings`` both return only the local
+  config now. However, the returned object has a ``global_conf`` attribute
+  containing the defaults as well as a ``loader`` attribute pointing at
+  the loader instance.
+  See https://github.com/Pylons/plaster_pastedeploy/pull/8
+
 0.3.2 (2017-07-01)
 ==================
 

--- a/tests/test_get_settings.py
+++ b/tests/test_get_settings.py
@@ -31,6 +31,10 @@ class TestSimpleUri(object):
             ('b', 'default_b'),
         ]
 
+        assert result.global_conf['default_a'] == 'default_a'
+        assert result.global_conf['default_b'] == 'override_b'
+        assert result.loader == self.loader
+
         with pytest.raises(Exception):
             self.loader.get_settings('section2')
 
@@ -41,15 +45,24 @@ class TestSimpleUri(object):
         assert result['b'] == 'default_b'
         assert 'default_c' not in result
 
+        assert result.global_conf['default_a'] == 'default_a'
+        assert result.global_conf['default_b'] == 'override_b'
+        assert result.global_conf['default_c'] == 'default_c'
+
         result = self.loader.get_settings('section2', defaults=defaults)
         assert result['a'] == 'a_val'
         assert result['b'] == 'b_val'
         assert result['c'] == 'default_c'
 
+        assert result.global_conf['default_a'] == 'default_a'
+        assert result.global_conf['default_b'] == 'default_b'
+        assert result.global_conf['default_c'] == 'default_c'
+
     def test_environ_passed(self, monkeypatch):
         monkeypatch.setenv('PLASTER_FOO', 'bar')
         result = self.loader.get_settings('section3')
         assert result['foo'] == 'bar'
+        assert result.global_conf['ENV_PLASTER_FOO'] == 'bar'
 
 class TestSectionedURI(TestSimpleUri):
     config_uri = test_settings_path + '#section1'

--- a/tests/test_get_wsgi_app_settings.py
+++ b/tests/test_get_wsgi_app_settings.py
@@ -14,36 +14,12 @@ class TestFullURI(object):
         self.loader = plaster.get_loader(
             test_config_relpath, protocols=['wsgi'])
 
-    def test_get_wsgi_app_settings(self, monkeypatch):
-        from collections import OrderedDict
-        from paste.deploy import loadwsgi
-        from plaster_pastedeploy import ConfigDict
-
-        monkeypatch.setattr('os.environ', {})
-        conf = self.loader.get_wsgi_app_settings('test_get')
-
-        assert conf == {
-            'def1': 'a',
-            'def2': 'TEST',
-            'basepath': os.path.dirname(test_config_path),
-            'here': os.path.dirname(test_config_path),
-            '__file__': test_config_path,
-            'foo': 'TEST'}
-
-        assert conf.local_conf == {
-            'def1': 'a',
-            'foo': 'TEST'}
-        assert conf.global_conf == {
-            'def1': 'a',
-            'def2': 'TEST',
-            'basepath': os.path.dirname(test_config_path),
-            'here': os.path.dirname(test_config_path),
-            '__file__': test_config_path,
-        }
-
-        assert isinstance(conf, OrderedDict)
-        assert isinstance(conf, loadwsgi.AttrDict)
-        assert isinstance(conf, ConfigDict)
+    def test_get_wsgi_app_settings(self):
+        result = self.loader.get_wsgi_app_settings('test_get')
+        assert result == {'def1': 'a', 'foo': 'TEST'}
+        assert result.global_conf['def1'] == 'a'
+        assert result.global_conf['def2'] == 'TEST'
+        assert 'basepath' in result.global_conf
 
     def test_invalid_name(self):
         with pytest.raises(LookupError):
@@ -71,7 +47,7 @@ class TestEggURI(object):
 
     def test_it(self):
         conf = self.loader.get_wsgi_app_settings()
-        assert conf.global_conf['here'] == os.getcwd()
+        assert conf == {}
 
     def test_invalid_name(self):
         with pytest.raises(LookupError):


### PR DESCRIPTION
This is a bw-incompatible change for Pyramid and anyone using the `pyramid.paster.get_appsettings` API but I don't think it's important. I use this API myself and had never noticed or depended on the fact that it automatically merged the `global_conf` and the `local_conf`. If someone is, then they can replicate it easily as the `global_conf` is still available on the returned value.