### PR TITLE
Fix ConfigDict.copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+Next Release
+============
+
+- Fix ``ConfigDict.copy`` so that it works.
+
 0.4.1 (2017-07-10)
 ==================
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,3 +108,4 @@ Contributors
 
 - Michael Merickel (2016-06-12)
 - Steve Piercy (2017-08-31)
+- Geoffrey T. Dairiki (2017-11-16)

--- a/src/plaster_pastedeploy/__init__.py
+++ b/src/plaster_pastedeploy/__init__.py
@@ -275,3 +275,11 @@ class ConfigDict(OrderedDict, loadwsgi.AttrDict):
         super(ConfigDict, self).__init__(local_conf)
         self.global_conf = global_conf
         self.loader = loader
+
+    def __reduce__(self):
+        initargs = list(self.items()), self.global_conf, self.loader
+        return self.__class__, initargs
+
+    def copy(self):
+        callable, args = self.__reduce__()
+        return callable(*args)

--- a/tests/test_configdict.py
+++ b/tests/test_configdict.py
@@ -1,0 +1,31 @@
+""" Tests for plaster_pastedeploy.ConfigDict
+"""
+import copy                     # noqa: F401
+import plaster
+import pytest
+
+
+@pytest.fixture
+def loader():
+    from plaster_pastedeploy import Loader
+    uri = plaster.PlasterURL('pastedeploy+ini', 'development.ini')
+    return Loader(uri)
+
+
+@pytest.mark.parametrize('copy_method', [
+    "configdict.copy()",
+    "copy.copy(configdict)",
+    ])
+def test_copy(copy_method, loader):
+    from plaster_pastedeploy import ConfigDict
+    x = []
+    global_conf = {}
+    configdict = ConfigDict({'x': x}, global_conf, loader)
+
+    duplicate = eval(copy_method)
+
+    assert duplicate.items() == configdict.items()
+    # check that we got a shallow copy
+    assert duplicate['x'] is x
+    assert duplicate.global_conf is global_conf
+    assert duplicate.loader is loader

--- a/tests/test_configdict.py
+++ b/tests/test_configdict.py
@@ -12,17 +12,24 @@ def loader():
     return Loader(uri)
 
 
-@pytest.mark.parametrize('copy_method', [
-    "configdict.copy()",
-    "copy.copy(configdict)",
-    ])
-def test_copy(copy_method, loader):
+def dict_copy(d):
+    return d.copy()
+
+
+def copy_copy(d):
+    return copy.copy(d)
+
+
+@pytest.mark.parametrize('copier',
+                         [dict_copy, copy_copy],
+                         ids=lambda f: f.__name__)
+def test_copy(copier, loader):
     from plaster_pastedeploy import ConfigDict
     x = []
     global_conf = {}
     configdict = ConfigDict({'x': x}, global_conf, loader)
 
-    duplicate = eval(copy_method)
+    duplicate = copier(configdict)
 
     assert duplicate.items() == configdict.items()
     # check that we got a shallow copy


### PR DESCRIPTION
Buglet:

This fixes the `ConfigDict.copy` method so that it works.  Currently `ConfigDict` inherits the `copy` and `__reduce__` methods from `OrderedDict`.  Neither work for `ConfigDict`. (Both raise `TypeError: __init__() takes exactly 4 arguments (2 given)`.)

This patch fixes things so that both `ConfigDict.copy()` and `copy.copy(configdict)` work correctly.