### PR TITLE
Switch from pkg_resources to importlib

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,18 @@
+import importlib
 import os.path
 import sys
 
-import pkg_resources
 import pytest
 
 
 @pytest.fixture(scope="session")
 def fake_packages():
-    # we'd like to keep this scope more focused but it's proven really
-    # difficult to fully monkeypatch pkg_resources and so for now we just
-    # install the packages for the duration of the test suite
+    # We'd like to keep this scope more focused.  It proved really
+    # difficult to fully monkeypatch pkg_resources and so we just
+    # installed the packages for the duration of the test suite.
+    # The scope was left as-is after switching from pkg_resources to
+    # importlib.
     test_dir = os.path.dirname(__file__)
     info_dir = os.path.join(test_dir, "fake_packages", "FakeApp")
     sys.path.insert(0, info_dir)
-    pkg_resources.working_set.add_entry(info_dir)
+    importlib.import_module("fakeapp")


### PR DESCRIPTION
pkg_resources is depreciated.  This gets rid of depcrecation warnings.