### PR TITLE
Drop support for Python 3.7; complete Python 3.11 CI workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,7 +15,6 @@ jobs:
         strategy:
             matrix:
                 py:
-                    - "3.7"
                     - "3.8"
                     - "3.9"
                     - "3.10"
@@ -51,14 +50,14 @@ jobs:
         name: Validate coverage
         steps:
             - uses: actions/checkout@v4
-            - name: Setup python 3.10
+            - name: Setup python 3.11
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.10"
+                  python-version: "3.11"
                   architecture: x64
 
             - run: pip install tox
-            - run: tox -e py310,coverage
+            - run: tox -e py311,coverage
     lint:
         runs-on: ubuntu-latest
         name: Lint the package
@@ -67,7 +66,7 @@ jobs:
             - name: Setup python
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.10"
+                  python-version: "3.11"
                   architecture: x64
             - run: pip install tox
             - run: tox -e lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 41"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 exclude = '''
 /(
   \.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +37,7 @@ install_requires =
     PasteDeploy >= 2.0
     plaster >= 0.5
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py37,py38,py39,py310,py311,pypy3,
+    py38,py39,py310,py311,pypy3,
     coverage
 
 [testenv]


### PR DESCRIPTION
Niether the Python Software Foundation nor pytest supports Python 3.7.

The CI tooling did not appear to use Python 3.11 consistently.